### PR TITLE
Add/dockerfile patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,27 @@ ENV CARGO_HOME="/opt/cargo" \
     RUSTUP_HOME="/opt/rustup"
 ENV PATH="$CARGO_HOME/bin:$PATH"
 RUN mkdir $CARGO_HOME $RUSTUP_HOME \
-    && chmod -R a+s $CARGO_HOME $RUSTUP_HOME \
+    && chmod a+rws $CARGO_HOME $RUSTUP_HOME \
     && curl -fsSL --proto '=https' --tlsv1.2 https://sh.rustup.rs \
     | sh -s -- -y --quiet --no-modify-path \
     && rustup update \
-    && cargo install ripgrep \
-    # Allow non-root users to install toolchains and update rust crates.
-    && chmod 777 $RUSTUP_HOME/toolchains $RUSTUP_HOME/update-hashes $CARGO_HOME/registry \
-    && chmod -R a+rw $CARGO_HOME/registry
+    && cargo install ripgrep
 
 # Install system dependencies.
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         gettext \
         lame \
+        libnss3 \
+        libxcb-icccm4 \
+        libxcb-image0 \
+        libxcb-keysyms1 \
+        libxcb-randr0 \
+        libxcb-render-util0 \
+        libxcb-xinerama0 \
+        libxcb-xkb1 \
+        libxkbcommon-x11-0 \
+        libxcomposite1 \
         mpv \
         portaudio19-dev \
         rsync \
@@ -42,8 +49,11 @@ RUN curl -fsSL --proto '=https' -O https://github.com/protocolbuffers/protobuf/r
     && rm protoc-3.11.4-linux-x86_64.zip
 ENV PATH="/opt/protoc/bin:$PATH"
 
-RUN chmod 777 $RUSTUP_HOME \
-    && chmod 777 $CARGO_HOME
+# Allow non-root users to install toolchains and update rust crates.
+RUN chmod 777 $RUSTUP_HOME/toolchains $RUSTUP_HOME/update-hashes $CARGO_HOME/registry \
+    && chmod -R a+rw $CARGO_HOME/registry \
+    # Necessary for TypeScript.
+    && chmod a+w /home
 
 # Build anki. Use a separate image so users can build an image with build-time
 # dependencies.

--- a/README.docker
+++ b/README.docker
@@ -1,0 +1,27 @@
+# Anki in Docker
+
+Docker provides a standard method of installing software. This is particularly helpful when software requires a complex set of dependencies, like Anki.
+
+## Developing Anki in Docker
+
+Build your local source tree in Docker.
+
+1. Build the Docker image with build-time dependencies. The Anki Dockerfile uses multi-stage builds, so the target is the first stage, which includes only the dependencies.
+
+```
+docker build --tag anki:dependencies --target dependencies .
+```
+
+2. Compile your source tree
+
+Important to run as the current user. Find user id with `id -u` and group ID with `id -g`. If this is not done, files will be owned by root.
+
+```
+docker run --rm -it --name ankibuilder --detach --volume $PWD:/work --workdir /work --user 1000:1000 anki:dependencies bash
+```
+
+Compile the code here.
+
+```
+docker exec -it ankibuilder make develop
+```

--- a/README.docker
+++ b/README.docker
@@ -1,27 +1,99 @@
-# Anki in Docker
+Anki in Docker
+==============
 
-Docker provides a standard method of installing software. This is particularly helpful when software requires a complex set of dependencies, like Anki.
+Docker provides a standard method of installing software. This is particularly helpful
+when software requires a complex set of dependencies, like Anki.
+
+## Running Anki in Docker
+
+Build and then run the image. The `docker run` command below runs the image as the
+current user, and it mounts the user's `$HOME` directory, which is where Anki stores
+its local files.
+
+```
+docker build --tag anki .
+xhost +local:root  # Undo when done with `xhost -local:root`
+docker run \
+    --rm -it \
+    --user 1000:1000 \
+    --volume $HOME/.local/share:$HOME/.local/share:rw \
+    --volume /etc/passwd:/etc/passwd:ro \
+    --volume /tmp/.X11-unix:/tmp/.X11-unix:rw \
+    --env DISPLAY=$DISPLAY \
+    anki
+xhost -local:root
+```
 
 ## Developing Anki in Docker
 
 Build your local source tree in Docker.
 
-1. Build the Docker image with build-time dependencies. The Anki Dockerfile uses multi-stage builds, so the target is the first stage, which includes only the dependencies.
+1. Build the Docker image with build-time dependencies. The Anki Dockerfile uses
+multi-stage builds, so the target is the first stage, which includes only the
+dependencies.
 
-```
-docker build --tag anki:dependencies --target dependencies .
-```
+    ```
+    docker build --tag anki:dependencies --target dependencies .
+    ```
 
 2. Compile your source tree
 
-Important to run as the current user. Find user id with `id -u` and group ID with `id -g`. If this is not done, files will be owned by root.
+    Start the image with dependencies in the background. It is important to run the
+    image as the current user, because otherwise, some files in the source tree will be
+    owned by root. Find user id with `id -u` and group ID with `id -g`. These values
+    are passed to `--user` as in `--user $(id -u):$(id -g)`.
 
-```
-docker run --rm -it --name ankibuilder --detach --volume $PWD:/work --workdir /work --user 1000:1000 anki:dependencies bash
-```
+    ```
+    docker run --rm -it \
+        --name ankibuilder \
+        --detach \
+        --workdir /work
+        --volume "$PWD":/work:rw \
+        --user 1000:1000 \
+        --volume /etc/passwd:/etc/passwd:ro \
+        --volume /tmp/.X11-unix:/tmp/.X11-unix:rw \
+        --env DISPLAY=$DISPLAY \
+        anki:dependencies bash
+    ```
 
-Compile the code here.
+    Allow the Docker container to use the local X server and show the GUI.
 
-```
-docker exec -it ankibuilder make develop
-```
+    ```
+    xhost +local:root
+    ```
+
+    (Undo this when done with `xhost -local:root`)
+
+    Compile.
+
+    ```
+    docker exec -it ankibuilder make run
+    ```
+
+    The Anki graphical user interface should appear. The first run will take some time
+    because Rust code has to be compiled and Python dependencies have to be downloaded,
+    etc. The following runs will be much faster.
+
+    To compile without running the GUI, use `make develop`.
+
+3. Other common operations
+
+    If system packages need to be installed, use `apt-get` as below. The Docker image
+    is based on a Debian Stable image.
+
+    ```
+    docker exec -it --user root ankibuilder apt-get update
+    docker exec -it --user root ankibuilder apt-get install PACKAGES
+    ```
+
+    An interactive bash shell can be started with
+
+    ```
+    docker exec -it ankibuilder bash
+    ```
+
+    or as root user
+
+    ```
+    docker exec -it --user root ankibuilder bash
+    ```


### PR DESCRIPTION
- Fix permissions in `/opt` to allow non-root user to compile Anki (which requires reading and/or creating files below `/opt`).
- Create `pythonbuilder` stage, which runs only `make build`. The wheels from this stage are copied into the final stage.
- Add README.docker